### PR TITLE
Fix decapsulation failure

### DIFF
--- a/kem.go
+++ b/kem.go
@@ -190,7 +190,7 @@ func KemDecrypt512(
 	ski := Kyber512SKBytes - 2*paramsSymBytes
 	kr := sha3.Sum512(append(buf, privateKey[ski:ski+paramsSymBytes]...))
 	cmp, err := indcpaEncrypt(buf, publicKey, kr[paramsSymBytes:], paramsK)
-	fail := byte(1 - subtle.ConstantTimeCompare(ciphertext[:], cmp))
+	fail := byte(subtle.ConstantTimeCompare(ciphertext[:], cmp) - 1)
 	krh := sha3.Sum256(ciphertext[:])
 	for i := 0; i < paramsSymBytes; i++ {
 		skx := privateKey[:Kyber512SKBytes-paramsSymBytes+i]
@@ -219,7 +219,7 @@ func KemDecrypt768(
 	ski := Kyber768SKBytes - 2*paramsSymBytes
 	kr := sha3.Sum512(append(buf, privateKey[ski:ski+paramsSymBytes]...))
 	cmp, err := indcpaEncrypt(buf, publicKey, kr[paramsSymBytes:], paramsK)
-	fail := byte(1 - subtle.ConstantTimeCompare(ciphertext[:], cmp))
+	fail := byte(subtle.ConstantTimeCompare(ciphertext[:], cmp) - 1)
 	krh := sha3.Sum256(ciphertext[:])
 	for i := 0; i < paramsSymBytes; i++ {
 		skx := privateKey[:Kyber768SKBytes-paramsSymBytes+i]
@@ -248,7 +248,7 @@ func KemDecrypt1024(
 	ski := Kyber1024SKBytes - 2*paramsSymBytes
 	kr := sha3.Sum512(append(buf, privateKey[ski:ski+paramsSymBytes]...))
 	cmp, err := indcpaEncrypt(buf, publicKey, kr[paramsSymBytes:], paramsK)
-	fail := byte(1 - subtle.ConstantTimeCompare(ciphertext[:], cmp))
+	fail := byte(subtle.ConstantTimeCompare(ciphertext[:], cmp) - 1)
 	krh := sha3.Sum256(ciphertext[:])
 	for i := 0; i < paramsSymBytes; i++ {
 		skx := privateKey[:Kyber1024SKBytes-paramsSymBytes+i]


### PR DESCRIPTION
There's a bug that essentially breaks the current implementation; this PR patches it. I'll explain it briefly.

Kyber detects decryption failure by comparing the given and expected ciphertexts:
```go
fail := byte(1 - subtle.ConstantTimeCompare(ciphertext[:], cmp))
```

Here `subtle.ConstantTimeCompare` returns `1` if decryption succeeded, and `0` on failure. Hence `fail` is `0` on success, and `1` on failure. On failure, Kyber should overwrite the decapsulated key with a secret dummy value. However, since `fail` is `0b00000001` only the lowest bit of each byte is overwritten.

```go
for i := 0; i < paramsSymBytes; i++ {
	skx := privateKey[:Kyber512SKBytes-paramsSymBytes+i]
	kr[i] = kr[i] ^ (fail & (kr[i] ^ skx[i]))
}
```

This effectively turns the KEM into a CPA-secure scheme, which you can break with about log N queries and 2^32 hashes computed locally. The fix is pretty simple: `fail` needs to be `0xff` on failure.