### PR TITLE
Remove possible variable-time division

### DIFF
--- a/byteops.go
+++ b/byteops.go
@@ -60,7 +60,7 @@ func byteopsCbd(buf []byte, paramsK int) poly {
 // byteopsMontgomeryReduce computes a Montgomery reduction; given
 // a 32-bit integer `a`, returns `a * R^-1 mod Q` where `R=2^16`.
 func byteopsMontgomeryReduce(a int32) int16 {
-	u := int16(a * int32(paramsQinv))
+	u := int16(a * int32(paramsQInv))
 	t := int32(u) * int32(paramsQ)
 	t = a - t
 	t >>= 16

--- a/params.go
+++ b/params.go
@@ -5,8 +5,9 @@ package kyberk2so
 
 const paramsN int = 256
 const paramsQ int = 3329
-const paramsQinv int = 62209
-const paramsQdiv uint32 = 80635
+const paramsQDivBy2Ceil uint32 = 1665
+const paramsQPolyToMsg uint32 = 80635
+const paramsQInv int = 62209
 const paramsSymBytes int = 32
 const paramsPolyBytes int = 384
 const paramsETAK512 int = 3

--- a/params.go
+++ b/params.go
@@ -6,6 +6,7 @@ package kyberk2so
 const paramsN int = 256
 const paramsQ int = 3329
 const paramsQinv int = 62209
+const paramsQdiv uint32 = 80635
 const paramsSymBytes int = 32
 const paramsPolyBytes int = 384
 const paramsETAK512 int = 3

--- a/poly.go
+++ b/poly.go
@@ -124,8 +124,8 @@ func polyToMsg(a poly) []byte {
 	for i := 0; i < paramsN/8; i++ {
 		msg[i] = 0
 		for j := 0; j < 8; j++ {
-			t = ((uint32(a[8*i+j]) << 1) + uint32(paramsQ/2))
-			t = ((t * paramsQdiv) >> 28) & 1
+			t = (uint32(a[8*i+j]) << 1) + paramsQDivBy2Ceil
+			t = ((t * paramsQPolyToMsg) >> 28) & 1
 			msg[i] |= byte(t << j)
 		}
 	}

--- a/poly.go
+++ b/poly.go
@@ -119,12 +119,13 @@ func polyFromMsg(msg []byte) poly {
 // and represents the inverse of polyFromMsg.
 func polyToMsg(a poly) []byte {
 	msg := make([]byte, paramsSymBytes)
-	var t uint16
+	var t uint32
 	a = polyCSubQ(a)
 	for i := 0; i < paramsN/8; i++ {
 		msg[i] = 0
 		for j := 0; j < 8; j++ {
-			t = (((uint16(a[8*i+j]) << 1) + uint16(paramsQ/2)) / uint16(paramsQ)) & 1
+			t = ((uint32(a[8*i+j]) << 1) + uint32(paramsQ/2))
+			t = ((t * paramsQdiv) >> 28) & 1
 			msg[i] |= byte(t << j)
 		}
 	}


### PR DESCRIPTION
This commit removes a potential variable-time division which may occur in `polyToMsg`. The fix is based on the following change to the reference code:

https://github.com/pq-crystals/kyber/commit/dda29cc63af721981ee2c831cf00822e69be3220

The above fix to the reference code appears to have come as a result of the issue being reported to the Kyber team by the Cryspen team (Goutam Tavada, Karthikeyan Bhargavan and Franziskus Kiefer).

The variable-time division first made it into Kyber-K2SO as a result of this code being based on the Kyber reference implementation from which we copy the fix here.

Finally, fixing this issue appears to negatively impact performance benchmarks. Before the fix:

```
goos: linux
goarch: amd64
pkg: github.com/symbolicsoft/kyber-k2so
cpu: 13th Gen Intel(R) Core(TM) i7-1360P
BenchmarkKemKeypair512-16          17241             58059 ns/op
BenchmarkKemKeypair768-16           9544            111643 ns/op
BenchmarkKemKeypair1024-16          6648            156460 ns/op
BenchmarkKemEncrypt512-16          16389             76382 ns/op
BenchmarkKemEncrypt768-16          10000            122497 ns/op
BenchmarkKemEncrypt1024-16          5888            178981 ns/op
BenchmarkKemDecrypt512-16          13976             85318 ns/op
BenchmarkKemDecrypt768-16           8008            137430 ns/op
BenchmarkKemDecrypt1024-16          5558            202413 ns/op
PASS
ok      github.com/symbolicsoft/kyber-k2so      13.837s
```

After the fix:

```
goos: linux
goarch: amd64
pkg: github.com/symbolicsoft/kyber-k2so
cpu: 13th Gen Intel(R) Core(TM) i7-1360P
BenchmarkKemKeypair512-16          20779             56627 ns/op
BenchmarkKemKeypair768-16          12062             99456 ns/op
BenchmarkKemKeypair1024-16          7518            154263 ns/op
BenchmarkKemEncrypt512-16          15798             70288 ns/op
BenchmarkKemEncrypt768-16           8662            121981 ns/op
BenchmarkKemEncrypt1024-16          6547            179181 ns/op
BenchmarkKemDecrypt512-16          14059             84058 ns/op
BenchmarkKemDecrypt768-16           8001            136209 ns/op
BenchmarkKemDecrypt1024-16          4869            225456 ns/op
PASS
ok      github.com/symbolicsoft/kyber-k2so      16.006s
```

Relevant issue #7 in the Kyber-K2SO repository:
https://github.com/symbolicsoft/kyber-k2so/issues/7