### PR TITLE
security: zeroize prfInput in indcpaPrf to prevent seed leakage

### DIFF
--- a/indcpa.go
+++ b/indcpa.go
@@ -153,7 +153,7 @@ func indcpaPrf(dst []byte, prf sha3.ShakeHash, key []byte, nonce byte) {
 	prf.Reset()
 	_, _ = prf.Write(prfInput[:])
        	_, _ = prf.Read(dst)
-byteopsZeroBytes(prfInput[:]) // <--- The only change needed
+        byteopsZeroBytes(prfInput[:]) 
 }
 
 // indcpaKeypair generates public and private keys for the CPA-secure

--- a/indcpa.go
+++ b/indcpa.go
@@ -152,8 +152,8 @@ func indcpaPrf(dst []byte, prf sha3.ShakeHash, key []byte, nonce byte) {
 	prfInput[32] = nonce
 	prf.Reset()
 	_, _ = prf.Write(prfInput[:])
-       	_, _ = prf.Read(dst)
-        byteopsZeroBytes(prfInput[:]) 
+	_, _ = prf.Read(dst)
+	byteopsZeroBytes(prfInput[:])
 }
 
 // indcpaKeypair generates public and private keys for the CPA-secure

--- a/indcpa.go
+++ b/indcpa.go
@@ -152,7 +152,8 @@ func indcpaPrf(dst []byte, prf sha3.ShakeHash, key []byte, nonce byte) {
 	prfInput[32] = nonce
 	prf.Reset()
 	_, _ = prf.Write(prfInput[:])
-	_, _ = prf.Read(dst)
+       	_, _ = prf.Read(dst)
+byteopsZeroBytes(prfInput[:]) // <--- The only change needed
 }
 
 // indcpaKeypair generates public and private keys for the CPA-secure


### PR DESCRIPTION
## Summary
This PR adds a missing zeroization call in the `indcpaPrf` function to ensure sensitive cryptographic material is cleared from the stack after use.

## Problem
In `indcpa.go`, the `indcpaPrf` function copies secret key material (either `noiseSeed` or `coins`) into a local stack buffer `prfInput`. Currently, this buffer is not zeroized before the function returns. 

While the caller may zeroize the original seed, the verbatim copy remains on the goroutine stack until overwritten, which violates the library's "best-effort zeroization" policy stated in `SECURITY.md`.

## Solution
Added `byteopsZeroBytes(prfInput[:])` at the end of `indcpaPrf`. This aligns the function with the hardening patterns used throughout the rest of the CPA layer (e.g., in `indcpaKeypair` and `indcpaEncrypt`).

## Verification
Verified via manual memory inspection that the seed persists on the stack without this change and is successfully cleared with it.